### PR TITLE
Upgrade node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: The number of the issue or pull request.
     required: false
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: users

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: The number of the issue or pull request.
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: users


### PR DESCRIPTION
## What this PR does / Why we need it
Node 12 is deprecated and creates a warning message during the workflow

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions-ecosystem/action-add-assignees@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/


## Which issue(s) this PR fixes
 A quick fix to update to node 16
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/